### PR TITLE
Split make entities and interfaces commands

### DIFF
--- a/EntityGeneratorBundle/Command/MakeInterfacesCommand.php
+++ b/EntityGeneratorBundle/Command/MakeInterfacesCommand.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace IvozDevTools\EntityGeneratorBundle\Command;
+
+use Symfony\Bundle\MakerBundle\ApplicationAwareMakerInterface;
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\FileManager;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\MakerInterface;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Used as the Command class for the makers.
+ *
+ * @internal
+ */
+final class MakeInterfacesCommand extends Command
+{
+    protected static $defaultName = 'ivoz:make:interfaces';
+
+    private $maker;
+    private $fileManager;
+    private $inputConfig;
+    /** @var ConsoleStyle */
+    private $io;
+    private $checkDependencies = true;
+    private $generator;
+
+    public function __construct(MakerInterface $maker, FileManager $fileManager, Generator $generator)
+    {
+        $this->maker = $maker;
+        $this->fileManager = $fileManager;
+        $this->inputConfig = new InputConfiguration();
+        $this->generator = $generator;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->maker->configureCommand($this, $this->inputConfig);
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->io = new ConsoleStyle($input, $output);
+        $this->fileManager->setIO($this->io);
+
+        if ($this->checkDependencies) {
+            $dependencies = new DependencyBuilder();
+            $this->maker->configureDependencies($dependencies, $input);
+
+            if (!$dependencies->isPhpVersionSatisfied()) {
+                throw new RuntimeCommandException('The make:entity command requires that you use PHP 7.1 or higher.');
+            }
+
+            if ($missingPackagesMessage = $dependencies->getMissingPackagesMessage($this->getName())) {
+                throw new RuntimeCommandException($missingPackagesMessage);
+            }
+        }
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (!$this->fileManager->isNamespaceConfiguredToAutoload($this->generator->getRootNamespace())) {
+            $this->io->note([
+                sprintf('It looks like your app may be using a namespace other than "%s".', $this->generator->getRootNamespace()),
+                'To configure this and make your life easier, see: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html#configuration',
+            ]);
+        }
+
+        foreach ($this->getDefinition()->getArguments() as $argument) {
+            if ($input->getArgument($argument->getName())) {
+                continue;
+            }
+
+            if (\in_array($argument->getName(), $this->inputConfig->getNonInteractiveArguments(), true)) {
+                continue;
+            }
+
+            $value = $this->io->ask($argument->getDescription(), $argument->getDefault(), [Validator::class, 'notBlank']);
+            $input->setArgument($argument->getName(), $value);
+        }
+
+        $this->maker->interact($input, $this->io, $this);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->maker->generate($input, $this->io, $this->generator);
+
+        // sanity check for custom makers
+        if ($this->generator->hasPendingOperations()) {
+            throw new \LogicException('Make sure to call the writeChanges() method on the generator.');
+        }
+
+        return 0;
+    }
+
+    public function setApplication(Application $application = null)
+    {
+        parent::setApplication($application);
+
+        if ($this->maker instanceof ApplicationAwareMakerInterface) {
+            if (null === $application) {
+                throw new \RuntimeException('Application cannot be null.');
+            }
+
+            $this->maker->setApplication($application);
+        }
+    }
+
+    /**
+     * @internal Used for testing commands
+     */
+    public function setCheckDependencies(bool $checkDeps)
+    {
+        $this->checkDependencies = $checkDeps;
+    }
+}

--- a/EntityGeneratorBundle/Doctrine/EntityInterface/InterfaceManipulator.php
+++ b/EntityGeneratorBundle/Doctrine/EntityInterface/InterfaceManipulator.php
@@ -53,12 +53,13 @@ final class InterfaceManipulator implements ManipulatorInterface
         $methodParameterArray = [];
         foreach ($methodParameters as $methodParameter) {
             $str = '';
+            $refType = $methodParameter->getType();
+
             try {
-                $refType = $methodParameter->getType();
-                $strType = $refType->getName();
-                $parameterClass = ! $refType->isBuiltin()
-                    ? $refType->getName()
-                    : null;
+                $parameterClass = null;
+                if ($refType instanceof \ReflectionNamedType && ! $refType->isBuiltin()) {
+                    $parameterClass = $refType->getName();
+                }
 
             } catch (\Exception $e) {
                 // Interface does not exist yet
@@ -78,10 +79,10 @@ final class InterfaceManipulator implements ManipulatorInterface
                         $str = '?' . $type . ' ';
                     }
                 }
-            } elseif ($methodParameter->getType()->getName() === 'array') {
+            } elseif ($refType instanceof \ReflectionNamedType && $refType->getName() === 'array') {
                 $str = 'array ';
             } elseif ($methodParameter->hasType()) {
-                $type = (string) $methodParameter->getType();
+                $type = (string) $refType;
                 $str = $type . ' ';
             }
 

--- a/EntityGeneratorBundle/Doctrine/Metadata/ClassMetadata.php
+++ b/EntityGeneratorBundle/Doctrine/Metadata/ClassMetadata.php
@@ -71,7 +71,6 @@ class ClassMetadata extends DoctrineClassMetadata
             }
 
             try {
-                /** @phpstan-ignore-next-line */
                 $this->reflFields[$field] = isset($mapping['declared'])
                     ? $reflService->getAccessibleProperty($mapping['declared'], $field)
                     : $reflService->getAccessibleProperty($this->name, $field);

--- a/EntityGeneratorBundle/Doctrine/Metadata/ClassMetadataFactory.php
+++ b/EntityGeneratorBundle/Doctrine/Metadata/ClassMetadataFactory.php
@@ -16,7 +16,7 @@ class ClassMetadataFactory extends DoctrineClassMetadataFactory
 {
     private $em;
 
-    public function setEntityManager(EntityManagerInterface $em)
+    public function setEntityManager(EntityManagerInterface $em): void
     {
         $this->em = $em;
         parent::setEntityManager($em);
@@ -25,7 +25,7 @@ class ClassMetadataFactory extends DoctrineClassMetadataFactory
     /**
      * {@inheritDoc}
      */
-    protected function newClassMetadataInstance($className)
+    protected function newClassMetadataInstance($className): ClassMetadata
     {
         return new ClassMetadata(
             $className,
@@ -33,7 +33,7 @@ class ClassMetadataFactory extends DoctrineClassMetadataFactory
         );
     }
 
-    protected function getParentClasses($name)
+    protected function getParentClasses($name): array
     {
         // Collect parent classes, ignoring transient (not-mapped) classes.
         $parentClasses = [];
@@ -51,14 +51,14 @@ class ClassMetadataFactory extends DoctrineClassMetadataFactory
         return $parentClasses;
     }
 
-    protected function initializeReflection(ClassMetadataInterface $class, ReflectionService $reflService)
+    protected function initializeReflection(ClassMetadataInterface $class, ReflectionService $reflService): void
     {
         try {
             parent::initializeReflection($class, $reflService);
         } catch (\Exception $e) {}
     }
 
-    protected function wakeupReflection(ClassMetadataInterface $class, ReflectionService $reflService)
+    protected function wakeupReflection(ClassMetadataInterface $class, ReflectionService $reflService): void
     {
         try {
             parent::wakeupReflection($class, $reflService);

--- a/EntityGeneratorBundle/Doctrine/Regenerator.php
+++ b/EntityGeneratorBundle/Doctrine/Regenerator.php
@@ -84,6 +84,17 @@ final class Regenerator
             $this->traitRegenerator->makeTrait($classMetadata);
             $this->entityRegenerator->makeEntity($classMetadata);
             $this->dtoRegenerator->makeDto($classMetadata);
+        }
+    }
+
+    public function regenerateInterfaces(string $classOrNamespace)
+    {
+        /** @var ClassMetadataInfo $classMetadata */
+        $classMetadata = $this->getMetadata($classOrNamespace);
+        $isMappedSuperclass = $classMetadata->isMappedSuperclass;
+        $isEmbeddedClass = $classMetadata->isEmbeddedClass;
+
+        if (!$isEmbeddedClass && !$isMappedSuperclass) {
             $this->interfaceRegenerator->makeInterface($classMetadata);
         }
     }

--- a/EntityGeneratorBundle/Maker/MakeInterfaces.php
+++ b/EntityGeneratorBundle/Maker/MakeInterfaces.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\Question;
 
-final class MakeEntities extends AbstractMaker implements InputAwareMakerInterface
+final class MakeInterfaces extends AbstractMaker implements InputAwareMakerInterface
 {
     private $fileManager;
     private $doctrineHelper;
@@ -48,7 +48,7 @@ final class MakeEntities extends AbstractMaker implements InputAwareMakerInterfa
 
     public static function getCommandName(): string
     {
-        return 'ivoz:make:entities';
+        return 'ivoz:make:interfaces';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConf)
@@ -637,7 +637,7 @@ final class MakeEntities extends AbstractMaker implements InputAwareMakerInterfa
             $generator
         );
 
-        $regenerator->regenerateEntities(
+        $regenerator->regenerateInterfaces(
             $classOrNamespace
         );
     }

--- a/EntityGeneratorBundle/Resources/config/services.yml
+++ b/EntityGeneratorBundle/Resources/config/services.yml
@@ -37,6 +37,28 @@ services:
       $generator: '@IvozDevTools\EntityGeneratorBundle\Generator'
     tags: [{ name: 'console.command', command: 'provider:make:entities' }]
 
+  IvozDevTools\EntityGeneratorBundle\Maker\MakeInterfaces:
+    arguments:
+      $fileManager: '@maker.file_manager'
+      $doctrineHelper: '@maker.doctrine_helper'
+      $generator: '@IvozDevTools\EntityGeneratorBundle\Generator'
+
+  IvozDevTools\EntityGeneratorBundle\Command\MakeInterfacesCommand:
+    arguments:
+      $maker: '@IvozDevTools\EntityGeneratorBundle\Maker\MakeInterfaces'
+      $fileManager: '@maker.file_manager'
+      $generator: '@IvozDevTools\EntityGeneratorBundle\Generator'
+    tags: [{ name: 'console.command' }]
+
+  provider.make.interfaces:
+    deprecated: "%service_id% is deprecated: use ivoz:make:entities instead"
+    class: IvozDevTools\EntityGeneratorBundle\Command\MakeEntitiesCommand
+    arguments:
+      $maker: '@IvozDevTools\EntityGeneratorBundle\Maker\MakeInterfaces'
+      $fileManager: '@maker.file_manager'
+      $generator: '@IvozDevTools\EntityGeneratorBundle\Generator'
+    tags: [{ name: 'console.command', command: 'provider:make:entities' }]
+
   IvozDevTools\EntityGeneratorBundle\Command\UpdateServiceCollectionsCommand:
     tags: [{ name: 'console.command' }]
 

--- a/EntityGeneratorBundle/Resources/skeleton/doctrine/AbstractEntity.tpl.php
+++ b/EntityGeneratorBundle/Resources/skeleton/doctrine/AbstractEntity.tpl.php
@@ -47,10 +47,7 @@ abstract class <?= $class_name."\n" ?>
     {
     }
 
-    /**
-     * @return <?= $parent_class_name ?>Dto
-     */
-    public static function createDto(string|int|null $id = null): DataTransferObjectInterface
+    public static function createDto(string|int|null $id = null): <?= $parent_class_name ?>Dto
     {
         return new <?= $parent_class_name ?>Dto($id);
     }


### PR DESCRIPTION
Make interfaces was causing issues because php doesn't refresh clases once they're loaded. Split ivoz:make:entities into ivoz:make:entities and ivoz:make:interfaces