### PR TITLE
added suport to blob field types

### DIFF
--- a/EntityGeneratorBundle/Doctrine/Dto/DtoManipulator.php
+++ b/EntityGeneratorBundle/Doctrine/Dto/DtoManipulator.php
@@ -118,6 +118,9 @@ final class DtoManipulator implements ManipulatorInterface
         $fieldName = $columnOptions['fieldName'];
         $isPk = in_array($fieldName, $classMetadata->identifier);
         $typeHint = $this->getEntityTypeHint($columnOptions['type']);
+        if ($typeHint === 'resource') {
+            $typeHint = 'string';
+        }
 
         $nullable = $columnOptions['nullable'] ?? false;
 

--- a/EntityGeneratorBundle/Doctrine/Entity/EntityManipulator.php
+++ b/EntityGeneratorBundle/Doctrine/Entity/EntityManipulator.php
@@ -141,10 +141,18 @@ final class EntityManipulator implements ManipulatorInterface
         $nullable = $columnOptions['nullable'] ?? false;
         $isId = (bool) ($columnOptions['id'] ?? false);
 
-        if ($nullable) {
-            $comments[] = '@var ?' . $typeHint;
+        if ($typeHint === 'resource') {
+            if ($nullable) {
+                $comments[] = '@var null | ' . $typeHint;
+            } else {
+                $comments[] = '@var ' . $typeHint;
+            }
         } else {
-            $comments[] = '@var ' . $typeHint;
+            if ($nullable) {
+                $comments[] = '@var ?' . $typeHint;
+            } else {
+                $comments[] = '@var ' . $typeHint;
+            }
         }
 
         $comments = array_merge(
@@ -206,7 +214,7 @@ final class EntityManipulator implements ManipulatorInterface
             );
         }
 
-        $returnHint = '@return ' . $typeHint;
+        $returnHint = '@return ' . ($typeHint !== 'resource' ? $typeHint : 'string');
         if ($nullable) {
             $returnHint .= ' | null';
         }

--- a/EntityGeneratorBundle/Doctrine/EntityTypeTrait.php
+++ b/EntityGeneratorBundle/Doctrine/EntityTypeTrait.php
@@ -10,10 +10,10 @@ trait EntityTypeTrait
             case 'string':
             case 'text':
             case 'guid':
+                return 'string';
             case 'binary':
             case 'blob':
-                return 'string';
-
+                return 'resource';
             case 'array':
             case 'simple_array':
             case 'json':

--- a/EntityGeneratorBundle/Doctrine/Getter.php
+++ b/EntityGeneratorBundle/Doctrine/Getter.php
@@ -25,9 +25,13 @@ class Getter implements CodeGeneratorUnitInterface
 
     public function toString(string $nlLeftPad = ''): string
     {
+        $returnType = $this->returnType !== 'resource'
+            ? $this->returnType
+            : 'string';
+
         $returnType = $this->isReturnTypeNullable
-            ? ': ?' . $this->returnType
-            : ': ' . $this->returnType;
+            ? ': ?' . $returnType
+            : ': ' . $returnType;
 
         if (is_null($this->returnType)) {
             $returnType = '';
@@ -55,6 +59,14 @@ class Getter implements CodeGeneratorUnitInterface
 
             $response[] = '    return ' . $stmt;
 
+        } else if ($this->returnType === 'resource') {
+            if ($this->isReturnTypeNullable) {
+                $response[] = '    if (is_null($this->' . $this->propertyName . ')) {';
+                $response[] = '        return null;';
+                $response[] = '    }';
+                $response[] = '';
+            }
+            $response[] = '    return stream_get_contents($this->' . $this->propertyName . ');';
         } else {
             $response[] = '    return $this->' . $this->propertyName . ';';
         }

--- a/EntityGeneratorBundle/Doctrine/Property.php
+++ b/EntityGeneratorBundle/Doctrine/Property.php
@@ -30,7 +30,11 @@ class Property implements CodeGeneratorUnitInterface
             return;
         }
 
-        $scapeCuotes = $defaultValue[0] === "'" && $defaultValue[strlen($defaultValue) -1] === "'";
+        $scapeCuotes =
+            !empty($defaultValue)
+            && $defaultValue[0] === "'"
+            && $defaultValue[strlen($defaultValue) -1] === "'";
+
         $this->defaultValue = $scapeCuotes
             ? substr($defaultValue, 1, -1)
             : $defaultValue;
@@ -43,15 +47,19 @@ class Property implements CodeGeneratorUnitInterface
 
     public function getHint(): string
     {
+        $typeHint = $this->typeHint !== 'resource'
+            ? $this->typeHint
+            : 'string';
+
         if ($this->required) {
-            return $this->typeHint;
+            return $typeHint;
         }
 
-        if (str_contains($this->typeHint, '|')) {
-            return 'null|' . $this->typeHint;
+        if (str_contains($typeHint, '|')) {
+            return 'null|' . $typeHint;
         }
 
-        return '?' . $this->typeHint;
+        return '?' . $typeHint;
     }
 
     public function getColumnName(): string
@@ -100,7 +108,7 @@ class Property implements CodeGeneratorUnitInterface
             $response[] = ' */';
         }
 
-        $attr = $this->visibility /*. ' ' . $this->getHint()*/ . ' $' . $this->name;
+        $attr = $this->visibility . ' $' . $this->name;
         if (!is_null($this->defaultValue) || !$this->isRequired()) {
 
             if ($this->defaultValue === 'null') {


### PR DESCRIPTION
Doctrine converts string variables into resources in order to persist them. This was causing hint issues  when you try to get de value back. 

This PR transforms blob values (strings) into resources in the entity itself, casting them back to string in getters