### PR TITLE
Error fixing

### DIFF
--- a/EntityGeneratorBundle/Doctrine/Dto/DtoManipulator.php
+++ b/EntityGeneratorBundle/Doctrine/Dto/DtoManipulator.php
@@ -338,6 +338,8 @@ final class DtoManipulator implements ManipulatorInterface
         $typeHint = $this->getEntityTypeHint($options['type']);
         if (in_array($typeHint, ['\\DateTime'], true)) {
             $typeHint = '\DateTimeInterface|string';
+        } else if ($typeHint === 'resource') {
+            $typeHint = 'string';
         }
 
         $typeHint = '@var ' . $typeHint . '|null';

--- a/EntityGeneratorBundle/Doctrine/EntityInterface/InterfaceManipulator.php
+++ b/EntityGeneratorBundle/Doctrine/EntityInterface/InterfaceManipulator.php
@@ -83,6 +83,15 @@ final class InterfaceManipulator implements ManipulatorInterface
                 $str = 'array ';
             } elseif ($methodParameter->hasType()) {
                 $type = (string) $refType;
+                $typeArgs = explode('|', $type);
+                foreach ($typeArgs as $k => $typeArg) {
+                    if ($typeArg === 'DateTimeInterface')  {
+                        $this->addUseStatementIfNecessary(
+                            'DateTimeInterface',
+                            $classMetadata
+                        );
+                    }
+                }
                 $str = $type . ' ';
             }
 

--- a/EntityGeneratorBundle/Doctrine/Repository/RepositoryRegenerator.php
+++ b/EntityGeneratorBundle/Doctrine/Repository/RepositoryRegenerator.php
@@ -26,7 +26,7 @@ final class RepositoryRegenerator
     {
         $classMetadata = clone $classMetadata;
         $entityNamespace = $classMetadata->name;
-        $interfaceNamespace = $classMetadata->name.'RepositoryInterface';
+        $interfaceNamespace = $classMetadata->name . 'Repository';
         $interfaceName = Str::getShortClassName($interfaceNamespace);
         $classMetadata->name = $classMetadata->customRepositoryClassName;
         if (class_exists($classMetadata->name)) {
@@ -68,11 +68,12 @@ final class RepositoryRegenerator
 
         $fqdn =
             $classMetadata->name
-            . 'RepositoryInterface';
+            . 'Repository';
 
-        if (class_exists($fqdn)) {
+        if (interface_exists($fqdn)) {
             return;
         }
+
         $classMetadata->name = $fqdn;
         $classMetadata->rootEntityName = $fqdn;
 

--- a/EntityGeneratorBundle/Maker/MakeEntities.php
+++ b/EntityGeneratorBundle/Maker/MakeEntities.php
@@ -3,6 +3,7 @@
 namespace IvozDevTools\EntityGeneratorBundle\Maker;
 
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use IvozDevTools\EntityGeneratorBundle\Doctrine\Regenerator;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
@@ -185,9 +186,8 @@ final class MakeEntities extends AbstractMaker implements InputAwareMakerInterfa
 
         $type = null;
         $types = Type::getTypesMap();
-        // remove deprecated json_array
-        /** @phpstan-ignore-next-line  */
-        unset($types[Type::JSON_ARRAY]);
+
+        unset($types[Types::JSON]);
 
         $allValidTypes = array_merge(
             array_keys($types),

--- a/EntityGeneratorBundle/Resources/skeleton/doctrine/AbstractEntity.tpl.php
+++ b/EntityGeneratorBundle/Resources/skeleton/doctrine/AbstractEntity.tpl.php
@@ -81,12 +81,11 @@ abstract class <?= $class_name."\n" ?>
      * Factory method
      * @internal use EntityTools instead
      * @param <?= $parent_class_name ?>Dto $dto
-     * @return static
      */
     public static function fromDto(
         DataTransferObjectInterface $dto,
         ForeignKeyTransformerInterface $fkTransformer
-    ): EntityInterface {
+    ): static {
         Assertion::isInstanceOf($dto, <?= $parent_class_name ?>Dto::class);
         /*__updateFromDto_assertions*/
 

--- a/EntityGeneratorBundle/Resources/skeleton/doctrine/RepositoryInterface.tpl.php
+++ b/EntityGeneratorBundle/Resources/skeleton/doctrine/RepositoryInterface.tpl.php
@@ -1,6 +1,7 @@
 <?= "<?php\n" ?>
 
 namespace <?= $namespace ?>;
+
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\Persistence\ObjectRepository;
 

--- a/EntityGeneratorBundle/Resources/skeleton/doctrine/Trait.tpl.php
+++ b/EntityGeneratorBundle/Resources/skeleton/doctrine/Trait.tpl.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace <?= $namespace ?>;
 
-use Ivoz\Core\Domain\Model\EntityInterface;
 use Ivoz\Core\Application\DataTransferObjectInterface;
 use Ivoz\Core\Application\ForeignKeyTransformerInterface;
 /*__class_use_statements*/
@@ -31,12 +30,11 @@ trait <?= $class_name."\n" ?>
      * Factory method
      * @internal use EntityTools instead
      * @param <?= $parent_class_name . "Dto" ?> $dto
-     * @return static
      */
     public static function fromDto(
         DataTransferObjectInterface $dto,
         ForeignKeyTransformerInterface $fkTransformer
-    ): EntityInterface {
+    ): static {
         /** @var static $self */
         $self = parent::fromDto($dto, $fkTransformer);
         /*__fromDto_setters*/


### PR DESCRIPTION
- Fixed error handling resource field types
- Fixed regression in InterfaceGenerator handling combined arguments hints (Datetime|string|null for instance)
- Removed Type::JSON_ARRAY references
- Replaced class_exists by interface_exists in order to check whether repository exists
- Reverted fromDto return type hint
