### PR TITLE
entity generator: handle bigints as string

### DIFF
--- a/EntityGeneratorBundle/Doctrine/EntityTypeTrait.php
+++ b/EntityGeneratorBundle/Doctrine/EntityTypeTrait.php
@@ -7,6 +7,7 @@ trait EntityTypeTrait
     private function getEntityTypeHint($doctrineType)
     {
         switch ($doctrineType) {
+            case 'bigint':
             case 'string':
             case 'text':
             case 'guid':
@@ -23,7 +24,6 @@ trait EntityTypeTrait
             case 'boolean':
                 return 'bool';
 
-            case 'bigint':
             case 'integer':
             case 'smallint':
                 return 'int';


### PR DESCRIPTION
https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/types.html#bigint
`Bigint values retrieved from the database are always converted to PHP's string type or null if no data is present.`