### PR TITLE
Update ivoz core to 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-bundle": "^2.0",
         "symfony/console": "^5.1",
         "symfony/maker-bundle": "<=1.38",
-        "irontec/ivoz-core": "^4.18.0"
+        "irontec/ivoz-core": "^5.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.0"


### PR DESCRIPTION
This will be released as version 6.0.
 Ivoz-core 5.0 introduces a breaking change in the testing system.